### PR TITLE
adding locks on counters to avoid concurent writes

### DIFF
--- a/lib/visit-counter/store/redis_store.rb
+++ b/lib/visit-counter/store/redis_store.rb
@@ -51,10 +51,14 @@ module VisitCounter
         end
 
         def with_lock(object, &block)
-          if aquire_lock!(object)
-            result = yield
+          begin
+            if aquire_lock!(object)
+              result = yield
+              unlock!(object)
+              result
+            end
+          rescue
             unlock!(object)
-            result
           end
         end
 

--- a/lib/visit-counter/store/redis_store.rb
+++ b/lib/visit-counter/store/redis_store.rb
@@ -34,6 +34,26 @@ module VisitCounter
           redis.set(key, 0)
         end
 
+        def substract(key, by)
+          redis.decrby(key, by)
+        end
+
+        def lock!(object)
+          redis.set(lock_key(object), 1)
+        end
+
+        def unlock!(object)
+          redis.del(lock_key(object))
+        end
+
+        def locked?(object)
+          redis.exists(lock_key(object))
+        end
+
+        def lock_key(object)
+          "#{object.class.name.downcase}_#{object.id}_object_cache_lock"
+        end
+
       end
     end
   end

--- a/lib/visit-counter/store/redis_store.rb
+++ b/lib/visit-counter/store/redis_store.rb
@@ -51,14 +51,12 @@ module VisitCounter
         end
 
         def with_lock(object, &block)
-          begin
-            if aquire_lock!(object)
-              result = yield
+          if aquire_lock!(object)
+            begin
+              yield
+            ensure
               unlock!(object)
-              result
             end
-          rescue
-            unlock!(object)
           end
         end
 

--- a/lib/visit-counter/visit_counter.rb
+++ b/lib/visit-counter/visit_counter.rb
@@ -72,7 +72,7 @@ module VisitCounter
       end
 
       def persist(object, staged_count, diff, name)
-        lock(object) do
+        VisitCounter::Store.engine.with_lock(object) do
           object.update_attribute(name, staged_count + diff)
           object.nullify_counter_cache(name, diff)
         end
@@ -83,15 +83,6 @@ module VisitCounter
           10
         elsif method.to_sym == :percent
           0.3
-        end
-      end
-
-      def lock(object)
-        unless VisitCounter::Store.engine.locked?(object)
-          VisitCounter::Store.engine.lock!(object)
-          result = yield
-          VisitCounter::Store.engine.unlock!(object)
-          result
         end
       end
 

--- a/spec/lib/visit_counter_spec.rb
+++ b/spec/lib/visit_counter_spec.rb
@@ -110,6 +110,31 @@ describe VisitCounter do
     end
   end
 
+  describe "locked objects" do
+    before :each do
+      @d = DummyObject.new
+      @d.stub!(:id).and_return(1)
+      @d.nullify_counter_cache(:counter)
+    end
+
+    it "should lock object when updating" do
+      VisitCounter::Helper.should_receive(:lock)
+      VisitCounter::Helper.persist(@d, 1, 1, :counter)
+    end
+
+    it "should not persist if object is locked" do
+      VisitCounter::Store.engine.stub!(:locked?).and_return(true)
+      @d.should_not_receive(:update_attribute)
+      VisitCounter::Helper.persist(@d, 1, 1, :counter)
+    end
+
+    it "should persist if object is locked" do
+      VisitCounter::Store.engine.stub!(:locked?).and_return(false)
+      @d.should_receive(:update_attribute)
+      VisitCounter::Helper.persist(@d, 1, 1, :counter)
+    end
+  end
+
   describe "overriding the getter" do
     before :all do
       DummyObject.cached_counter :counter


### PR DESCRIPTION
in order to avoid concurent writes to disk when there are a lot of visits to an object, we add a lock on it and only execute the persist call if there isn't any other lock on it. (currently only works with redis, which is anyway the only method we currently support)
