### PR TITLE
typo in method name - removing bang (no method without bang exists)

### DIFF
--- a/lib/visit-counter/store/redis_store.rb
+++ b/lib/visit-counter/store/redis_store.rb
@@ -38,7 +38,7 @@ module VisitCounter
           redis.decrby(key, by)
         end
 
-        def aquire_lock!(object)
+        def acquire_lock(object)
           redis.setnx(lock_key(object), 1)
         end
 
@@ -51,7 +51,7 @@ module VisitCounter
         end
 
         def with_lock(object, &block)
-          if aquire_lock!(object)
+          if acquire_lock(object)
             begin
               yield
             ensure

--- a/spec/lib/visit_counter_spec.rb
+++ b/spec/lib/visit_counter_spec.rb
@@ -124,13 +124,13 @@ describe VisitCounter do
     end
 
     it "should not persist if object is locked" do
-      VisitCounter::Store.engine.stub!(:aquire_lock!).and_return(false)
+      VisitCounter::Store.engine.stub!(:acquire_lock).and_return(false)
       @d.should_not_receive(:update_attribute)
       VisitCounter::Helper.persist(@d, 1, 1, :counter)
     end
 
     it "should persist if object is locked" do
-      VisitCounter::Store.engine.stub!(:aquire_lock!).and_return(true)
+      VisitCounter::Store.engine.stub!(:acquire_lock).and_return(true)
       @d.should_receive(:update_attribute)
       VisitCounter::Helper.persist(@d, 1, 1, :counter)
     end


### PR DESCRIPTION
- typo
- convention: remove bang unless there is a similar method without bang
