### PR TITLE
Feature - override threshold and update counters in time-range

### DIFF
--- a/lib/visit-counter/key.rb
+++ b/lib/visit-counter/key.rb
@@ -1,7 +1,23 @@
 module VisitCounter
   class Key
-    def self.key(object, method)
-      "visit_counter::#{object.class.to_s}::#{object.id}::#{method}"
+
+    attr_reader :object, :method
+    def initialize(object, method)
+      @object = object
+      @method = method
+    end
+
+    def self.generate(method, obj_class, obj_id = nil)
+      ["visit_counter", obj_class, obj_id, method].compact.join("::")
+    end
+
+    def generate_from_instance
+      object_class = self.object_class
+      Key.generate(method,object_class, self.object.id)
+    end
+
+    def object_class
+      object.class.to_s
     end
   end
 end

--- a/lib/visit-counter/store/redis_store.rb
+++ b/lib/visit-counter/store/redis_store.rb
@@ -22,16 +22,38 @@ module VisitCounter
           end
         end
 
-        def incr(key)
+        ## adding keys to sorted sets, to allow searching by timstamp(score).
+        ## subsequent hits to the same key will only update the timestamp (and won't duplicate).
+        def incr(key, timestamp, set_name)
+          redis.zadd(set_name, timestamp, key)
           redis.incr(key).to_i
+        end
+
+        def del(key)
+          redis.del(key)
         end
 
         def get(key)
           redis.get(key).to_i
         end
 
+        def mget(keys)
+          redis.mget(*keys).map(&:to_i)
+        end
+
         def nullify(key)
           redis.set(key, 0)
+        end
+
+        def mnullify(keys)
+          keys_with_0 = keys.flat_map {|k| [k,"0"]}
+          redis.mset(*keys_with_0)
+        end
+
+        ## Usage: to get all post#num_reads counters in the last hour, do:
+        ## redis.zrangebyscore("visit-counter::Post::num_reads", (Time.now - 3600).to_i, Time.now.to_i)
+        def get_all_by_range(sorted_set_key, min, max)
+          redis.zrangebyscore(sorted_set_key, min, max)
         end
 
         def substract(key, by)
@@ -59,7 +81,6 @@ module VisitCounter
             end
           end
         end
-
       end
     end
   end

--- a/lib/visit-counter/visit_counter.rb
+++ b/lib/visit-counter/visit_counter.rb
@@ -13,8 +13,10 @@ module VisitCounter
 
   module InstanceMethods
     def incr_counter(name)
-      key = VisitCounter::Key.key(self, name)
-      count = VisitCounter::Store.engine.incr(key)
+      key = VisitCounter::Key.new(self, name)
+      set_key = VisitCounter::Key.generate(key.method, key.object_class)
+      count = VisitCounter::Store.engine.incr(key.generate_from_instance, Time.now.to_i, set_key)
+
       staged_count = self.send(:read_attribute, name).to_i
       if Helper.passed_limit?(self, staged_count, count, name)
         Helper.persist(self, staged_count, count, name)
@@ -22,7 +24,7 @@ module VisitCounter
     end
 
     def get_counter_delta(name)
-      key = VisitCounter::Key.key(self, name)
+      key = VisitCounter::Key.new(self, name).generate_from_instance
       VisitCounter::Store.engine.get(key)
     end
 
@@ -34,16 +36,39 @@ module VisitCounter
     end
 
     def nullify_counter_cache(name, substract = nil)
-      key = VisitCounter::Key.key(self, name)
+      key = VisitCounter::Key.new(self, name).generate_from_instance
       if substract
         VisitCounter::Store.engine.substract(key, substract)
       else
         VisitCounter::Store.engine.nullify(key)
       end
     end
+
   end
 
   module ClassMethods
+
+    ## override counter threshold. update method counters from the given Time
+    ## E.g. Post.update_counters(:num_reads, 1.hour.ago) will all items that received hits in the last hour
+    def update_counters(name, from_time_ago)
+      set_name = VisitCounter::Key.generate(name, self)
+      counters_in_timeframe = VisitCounter::Store.engine.get_all_by_range(set_name, from_time_ago.to_i, Time.now.to_i)
+      obj_ids  = counters_in_timeframe.flat_map { |c| [c.split("::")[2].to_i] }
+      objects = self.where(id: obj_ids)
+
+      ## if no objects corresponding to the counters were found, remove them.
+      counters = Helper.reject_objectless_counters(counters_in_timeframe, objects, obj_ids)
+
+      hits, staged_count = Helper.get_count_stats(counters, objects, name)
+      self.transaction do
+        objects.zip(Helper.merge_array_values(hits, staged_count)).each do |o|
+          VisitCounter::Store.engine.with_lock(o[0]) do
+            o[0].class.update_all("#{name} = #{o[1]}", "id = #{o[0].id}")
+          end
+        end
+      end
+      VisitCounter::Store.engine.mnullify(counters)
+    end
 
     def cached_counter(name)
 
@@ -86,6 +111,20 @@ module VisitCounter
         end
       end
 
+      def merge_array_values(a1,a2)
+        a1.zip(a2).map {|i| i.inject(&:+)}
+      end
+
+      def reject_objectless_counters(counters, objects, counter_obj_ids)
+        delete_counter_ids = counter_obj_ids - objects.compact.map(&:id)
+        counters.reject {|c| delete_counter_ids.include?(c[2])}
+      end
+
+      def get_count_stats(counters, objects, name)
+        hits = VisitCounter::Store.engine.mget(counters).map(&:to_i)
+        staged_count = objects.map {|o| o.send(:read_attribute, name).to_i}
+        return hits, staged_count
+      end
     end
   end
 end

--- a/lib/visit-counter/visit_counter.rb
+++ b/lib/visit-counter/visit_counter.rb
@@ -49,7 +49,7 @@ module VisitCounter
   module ClassMethods
 
     ## override counter threshold. update method counters from the given Time
-    ## E.g. Post.update_counters(:num_reads, 1.hour.ago) will all items that received hits in the last hour
+    ## E.g. Post.update_counters(:num_reads, 1.hour.ago) will update all items that received hits in the last hour
     def update_counters(name, from_time_ago)
       set_name = VisitCounter::Key.generate(name, self)
       counters_in_timeframe = VisitCounter::Store.engine.get_all_by_range(set_name, from_time_ago.to_i, Time.now.to_i)

--- a/spec/lib/visit_counter_spec.rb
+++ b/spec/lib/visit_counter_spec.rb
@@ -158,4 +158,41 @@ describe VisitCounter do
     end
   end
 
+  describe "updating counters for the given time-period (disregarding threshold)" do
+    let(:d_key) {"visit_counter::DummyObject::1::counter"}
+    let(:d1_key) {"visit_counter::DummyObject::2::counter"}
+    let(:set_name) {"visit_counter::DummyObject::counter"}
+
+    before :each do
+      @d, @d1 = DummyObject.new, DummyObject.new
+      @d.stub(:id).and_return(1)
+      @d1.stub(:id).and_return(2)
+      DummyObject.stub(:transaction).and_yield
+      @d.nullify_counter_cache(:counter)
+      VisitCounter::Store.engine.redis.del set_name
+      @d.increase_counter
+      @d1.increase_counter
+    end
+
+    it "should update multiple objects" do
+      DummyObject.stub(:where).and_return([@d, @d1])
+      DummyObject.should_receive(:update_all).once.with("counter = 1", "id = 1").ordered
+      DummyObject.should_receive(:update_all).once.with("counter = 1", "id = 2").ordered
+      DummyObject.update_counters(:counter, (Time.now - 4))
+    end
+
+    it "should only find counter hits from the given time-period" do
+      VisitCounter::Store.engine.redis.zincrby(set_name, -100000, d1_key)
+      VisitCounter::Store.engine.get_all_by_range(set_name, (Time.now - 20).to_i, Time.now.to_i).should == [d_key]
+    end
+
+    it "should not try to update counters without objects" do
+      VisitCounter::Store.engine.should_receive(:get_all_by_range).and_return([d_key, d1_key])
+      DummyObject.stub(:where).and_return([@d])
+      VisitCounter::Helper.stub(:merge_array_values).and_return([0])
+      DummyObject.should_receive(:update_all).once
+      DummyObject.update_counters(:counter, (Time.now - 4))
+    end
+  end
+
 end


### PR DESCRIPTION
This feature will allow the application to pull all hits from the Redis, preventing a sticky situation where an object never makes it's threshold and never gets persisted in the db (notwithstanding #read_counter which shows the count on Redis)

Possible use cases for this is:  
- sweeping through all counters hourly to keep main db in sync with real numbers
- sweep daily to prevent data-loss (say Redis crashes and loses data)
- gem has a bug, user wants to stop using it and retrieve data until the bug's fixed.

Implementation:
Before counter is created/incremented, it's added to a Redis sorted set with current timestamp set as the score. This will allow for an efficient redis lookup for keys within time-periods (without key duplications).

The method #update_counters finds all relevant counters, filters counters of objects that have been deleted, and updates them in a single transaction with recently implemented locks. 

Problems with implementation:
# update_counters is using multiple #update_all, to prevent validation _and_ callbacks. didn't use update_attribute because it invokes callbacks and is apparently being  deprecated. Didn't use #update_column for backwards compatibility.

Didn't use Redis "transactions" (watch/multi) because the existing lock mechanism which does the job.
