### PR TITLE
Persist with callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ if you want the counter to persist to database once every 100 views.
 
 if you need to run callbacks for whatever reason after you update the counter just:
   
-   class Foo < ActiveRecord::Base
-      include VisitCounter
-      cached_counter :counter_name
-      self.persist_with_callbacks = true
-    end   
+  class Foo < ActiveRecord::Base
+    include VisitCounter
+    cached_counter :counter_name
+    self.update_callback_method = :update_something
+  end   
 
 ## Contributing
 

--- a/lib/visit-counter/visit_counter.rb
+++ b/lib/visit-counter/visit_counter.rb
@@ -4,7 +4,7 @@ module VisitCounter
     base.class_eval do
       class << self
         #defining class instance attributes
-        attr_accessor :visit_counter_threshold, :visit_counter_threshold_method, :update_callback_method_or_proc
+        attr_accessor :visit_counter_threshold, :visit_counter_threshold_method, :persist_with_callbacks
       end
     end
     base.send(:include, InstanceMethods)
@@ -74,12 +74,8 @@ module VisitCounter
       def persist(object, staged_count, diff, name)
         VisitCounter::Store.engine.with_lock(object) do
           object.update_attribute(name, staged_count + diff)
-          if mp = object.class.update_callback_method_or_proc
-            if mp.is_a?(Symbol) || mp.is_a?(String)
-              object.send(object.class.update_callback_method_or_proc)
-            elsif mp.is_a?(Proc)
-              mp.call(object)
-            end
+          if object.class.persist_with_callbacks
+            object.send(object.class.persist_with_callbacks)
           end
           object.nullify_counter_cache(name, diff)
         end

--- a/lib/visit-counter/visit_counter.rb
+++ b/lib/visit-counter/visit_counter.rb
@@ -4,7 +4,7 @@ module VisitCounter
     base.class_eval do
       class << self
         #defining class instance attributes
-        attr_accessor :visit_counter_threshold, :visit_counter_threshold_method, :persist_with_callbacks
+        attr_accessor :visit_counter_threshold, :visit_counter_threshold_method, :update_callback_method
       end
     end
     base.send(:include, InstanceMethods)
@@ -74,8 +74,8 @@ module VisitCounter
       def persist(object, staged_count, diff, name)
         VisitCounter::Store.engine.with_lock(object) do
           object.update_attribute(name, staged_count + diff)
-          if object.class.persist_with_callbacks
-            object.send(object.class.persist_with_callbacks)
+          if object.class.update_callback_method
+            object.send(object.class.update_callback_method)
           end
           object.nullify_counter_cache(name, diff)
         end

--- a/spec/lib/visit_counter_spec.rb
+++ b/spec/lib/visit_counter_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 class DummyObject
   include VisitCounter
 
-  attr_accessor :counter, :update_callback_method
+  attr_accessor :counter, :update_callback_method_or_proc
 
   def update_attribute(attribute, value)
     self.send("#{attribute}=", value)
@@ -163,13 +163,22 @@ describe VisitCounter do
   end
   
   describe "persist with callbacks" do
-    it "should use save method" do
+    it "should use update_something method" do
       @d = DummyObject.new
-      @d.class.update_callback_method = :update_something
+      @d.class.update_callback_method_or_proc = :update_something
       @d.stub!(:id).and_return(1)
       @d.should_receive(:update_something)
       @d.incr_counter :counter
-    end  
-  end  
+    end
+
+    it "should use save method" do
+      @d = DummyObject.new
+      proc = ->(p){ p *2 }
+      @d.class.update_callback_method_or_proc = proc
+      @d.stub!(:id).and_return(1)
+      proc.should_receive(:call).with(@d)
+      @d.incr_counter :counter
+    end
+  end
 
 end

--- a/spec/lib/visit_counter_spec.rb
+++ b/spec/lib/visit_counter_spec.rb
@@ -163,7 +163,7 @@ describe VisitCounter do
   end
   
   describe "persist with callbacks" do
-    it "should use save method" do
+    it "should use update_something method" do
       @d = DummyObject.new
       @d.class.update_callback_method = :update_something
       @d.stub!(:id).and_return(1)

--- a/spec/lib/visit_counter_spec.rb
+++ b/spec/lib/visit_counter_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 class DummyObject
   include VisitCounter
 
-  attr_accessor :counter, :update_callback_method_or_proc
+  attr_accessor :counter, :update_callback_method
 
   def update_attribute(attribute, value)
     self.send("#{attribute}=", value)
@@ -163,22 +163,13 @@ describe VisitCounter do
   end
   
   describe "persist with callbacks" do
-    it "should use update_something method" do
+    it "should use save method" do
       @d = DummyObject.new
-      @d.class.update_callback_method_or_proc = :update_something
+      @d.class.update_callback_method = :update_something
       @d.stub!(:id).and_return(1)
       @d.should_receive(:update_something)
       @d.incr_counter :counter
-    end
-
-    it "should use save method" do
-      @d = DummyObject.new
-      proc = ->(p){ p *2 }
-      @d.class.update_callback_method_or_proc = proc
-      @d.stub!(:id).and_return(1)
-      proc.should_receive(:call).with(@d)
-      @d.incr_counter :counter
-    end
-  end
+    end  
+  end  
 
 end

--- a/spec/lib/visit_counter_spec.rb
+++ b/spec/lib/visit_counter_spec.rb
@@ -3,13 +3,13 @@ require "spec_helper"
 class DummyObject
   include VisitCounter
 
-  attr_accessor :counter, :persist_with_callbacks
+  attr_accessor :counter, :update_callback_method
 
   def update_attribute(attribute, value)
     self.send("#{attribute}=", value)
   end
 
-  def save
+  def update_something
     nil
   end  
 
@@ -165,9 +165,9 @@ describe VisitCounter do
   describe "persist with callbacks" do
     it "should use save method" do
       @d = DummyObject.new
-      @d.class.persist_with_callbacks = true
+      @d.class.update_callback_method = :update_something
       @d.stub!(:id).and_return(1)
-      @d.should_receive(:save)
+      @d.should_receive(:update_something)
       @d.incr_counter :counter
     end  
   end  


### PR DESCRIPTION
we changed the functionality a bit, now instead of passing the gem a boolean value we pass a method and run it after the counter was updated
